### PR TITLE
29 - remove code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/458hoqaj6dr94jrj?svg=true)](https://ci.appveyor.com/project/ppittle/httpwebrequestwrapper)
 [![AppVeyor tests](https://img.shields.io/appveyor/tests/ppittle/httpwebrequestwrapper.svg?logo=appveyor)](https://ci.appveyor.com/project/ppittle/httpwebrequestwrapper/build/tests)
-[![Coverage Status](https://coveralls.io/repos/github/ppittle/HttpWebRequestWrapper/badge.svg)](https://coveralls.io/github/ppittle/HttpWebRequestWrapper)
 [![NuGet](https://img.shields.io/nuget/v/HttpWebRequestWrapper.svg)](https://www.nuget.org/packages/HttpWebRequestWrapper)
 [![NuGet](https://img.shields.io/nuget/dt/HttpWebRequestWrapper.svg)](https://www.nuget.org/packages/HttpWebRequestWrapper)
 


### PR DESCRIPTION
From #29 , build was salvageable but was unable to get code coverage metrics working.  Removing badge from README